### PR TITLE
New features for teleop_joystick

### DIFF
--- a/scitos_teleop/CMakeLists.txt
+++ b/scitos_teleop/CMakeLists.txt
@@ -4,7 +4,7 @@ project(scitos_teleop)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs message_generation)
 find_package(scitos_msgs COMPONENTS scitos_msgs)
 
 if(scitos_msgs_FOUND)
@@ -28,11 +28,10 @@ endif(scitos_msgs_FOUND)
 #######################################
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  action_buttons.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -42,10 +41,10 @@ endif(scitos_msgs_FOUND)
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -58,7 +57,7 @@ endif(scitos_msgs_FOUND)
 catkin_package(
    INCLUDE_DIRS include
 #  LIBRARIES rumblepad_control
-#  CATKIN_DEPENDS roscpp rospy std_msgs
+   CATKIN_DEPENDS roscpp rospy std_msgs message_runtime
 #  DEPENDS system_lib
 )
 

--- a/scitos_teleop/msg/action_buttons.msg
+++ b/scitos_teleop/msg/action_buttons.msg
@@ -1,0 +1,4 @@
+bool A
+bool B
+bool Y
+bool X

--- a/scitos_teleop/package.xml
+++ b/scitos_teleop/package.xml
@@ -43,7 +43,8 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>scitos_msgs</build_depend>
-
+  <build_depend>message_generation</build_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/scitos_teleop/src/rumble_control.cpp
+++ b/scitos_teleop/src/rumble_control.cpp
@@ -84,16 +84,16 @@ int main(int argc, char **argv)
    * You must call one of the versions of ros::init() before using any other
    * part of the ROS system.
    */
-  ros::init(argc, argv, "rumble_control");
+  ros::init(argc, argv, "teleop_joystick");
 
   /**
    * NodeHandle is the main access point to communications with the ROS system.
    * The first NodeHandle constructed will fully initialize this node, and the last
    * NodeHandle destructed will close down the node.
    */
-  ros::NodeHandle n("rumble_control");
-  n.param("scale_angular", a_scale_, 1.1);
-  n.param("scale_linear", l_scale_, 1.1);
+  ros::NodeHandle n("teleop_joystick");
+  n.param("scale_angular", a_scale_, 0.8);
+  n.param("scale_linear", l_scale_, 0.8);
   interrupt_broadcasting = false;
 
   /**

--- a/scitos_teleop/src/rumble_control.cpp
+++ b/scitos_teleop/src/rumble_control.cpp
@@ -22,13 +22,24 @@ double l_scale_, a_scale_;
 
 geometry_msgs::Twist t;
 
-bool interrupt_broadcasting;
+bool interrupt_broadcasting, sent_error;
 
 /**
  * This tutorial demonstrates simple receipt of messages over the ROS system.
  */
 void controlCallback(const sensor_msgs::Joy::ConstPtr& msg)
 {
+  //Check for X mode
+  if(msg->axes.size() != 8) {
+    if(!sent_error) {
+      ROS_ERROR("Rumblepad is running in D mode. Please switch to X mode.");
+      ROS_ERROR("Pad will not work as long as it runs in the wrong mode.");
+      sent_error = true;
+    }
+    return;
+  }
+  sent_error = false;
+
   //Publish action buttons
   scitos_teleop::action_buttons button_msg;
   button_msg.A = msg->buttons[0];
@@ -105,6 +116,7 @@ int main(int argc, char **argv)
   n.param("scale_angular", a_scale_, 0.8);
   n.param("scale_linear", l_scale_, 0.8);
   interrupt_broadcasting = false;
+  sent_error = false;
 
   /**
    * The subscribe() call is how you tell ROS that you want to receive messages


### PR DESCRIPTION
New features:
- The gamepad can now only be run in X mode (little switch between the shoulder buttons) to ensure that you always use the right button layout. If you put in D mode, the teleop_joystick will print an error message and won't do anything until it is switched back to X mode. The X and D mode have caused some confusion in the past because they change the layout of the axis and action buttons and the robot and all connected programmes behave unexpectedly.
- The teleop_joystick node is now publishing a custom massage for the action buttons. This message consists of 4 bool's (one for every button) and is published on /teleop_joystick/action_buttons. This has imho 2 major advantages over directly subscribing to the /joy topic to listen for buttons: 1. Above mentioned safety feature ensures that you always get a true for button A when button A is pressed and won't get confused because of the different layouts and 2. it is more convenient to use because of the unambiguous naming.

Bug fix:
The namespace of the teleop_joystick is now named accordingly and not rumblepad_control like before.
