### PR TITLE
Joystick name

### DIFF
--- a/scitos_teleop/launch/teleop_joystick.launch
+++ b/scitos_teleop/launch/teleop_joystick.launch
@@ -1,11 +1,11 @@
 <launch>
-  <!-- Joystic device path.
+  <!-- Joystick device path.
   Default is /dev/js1. If an environment variable JOYSTICK_DEVICE
   is set then this replaces the default. If the launch file is started with
   the argument js:=blah then blah overides both the default and the environment. -->
   <arg name="js" default="$(optenv JOYSTICK_DEVICE /dev/js1)" />
 
-  <!-- Joystic driver node -->
+  <!-- Joystick driver node -->
   <node pkg="joy" type="joy_node" name="joystick">
 	<param name="dev" value="$(arg js)" type="string"/>
 	<param name="autorepeat_rate" value="10.0" type="double"/>

--- a/scitos_teleop/launch/teleop_joystick.launch
+++ b/scitos_teleop/launch/teleop_joystick.launch
@@ -1,12 +1,23 @@
 <launch>
-        <node pkg="joy" type="joy_node" name="joystick">
-		<param name="dev" value="/dev/input/rumblepad" type="string"/>
-		<param name="autorepeat_rate" value="10.0" type="double"/>
-	</node>
-        <node pkg="scitos_teleop" type="rumble_control" name="teleop_joystick" output="screen">
-		<param name="scale_angular" value=".7" type="double"/>
-	        <param name="scale_linear" value=".7" type="double"/>
-	</node>
-        <node pkg="scitos_teleop" type="head_joy.py" name="teleop_joystick_head_control" />
-        <node pkg="scitos_teleop" type="eye_joy.py" name="teleop_joystick_eye_control" />
+  <!-- Joystic device path.
+  Default is /dev/js1. If an environment variable JOYSTICK_DEVICE
+  is set then this replaces the default. If the launch file is started with
+  the argument js:=blah then blah overides both the default and the environment. -->
+  <arg name="js" default="$(optenv JOYSTICK_DEVICE /dev/js1)" />
+
+  <!-- Joystic driver node -->
+  <node pkg="joy" type="joy_node" name="joystick">
+	<param name="dev" value="$(arg js)" type="string"/>
+	<param name="autorepeat_rate" value="10.0" type="double"/>
+  </node>
+
+  <!-- Base teleop -->
+  <node pkg="scitos_teleop" type="rumble_control" name="teleop_joystick" output="screen">
+	<param name="scale_angular" value=".7" type="double"/>
+	<param name="scale_linear" value=".7" type="double"/>
+  </node>
+
+  <!-- Head teleop -->
+  <node pkg="scitos_teleop" type="head_joy.py" name="teleop_joystick_head_control" />
+  <node pkg="scitos_teleop" type="eye_joy.py" name="teleop_joystick_eye_control" />
 </launch>

--- a/scitos_teleop/launch/teleop_joystick.launch
+++ b/scitos_teleop/launch/teleop_joystick.launch
@@ -1,6 +1,6 @@
 <launch>
         <node pkg="joy" type="joy_node" name="joystick">
-		<param name="dev" value="/dev/input/js1" type="string"/>
+		<param name="dev" value="/dev/input/rumblepad" type="string"/>
 		<param name="autorepeat_rate" value="10.0" type="double"/>
 	</node>
         <node pkg="scitos_teleop" type="rumble_control" name="teleop_joystick" output="screen">

--- a/scitos_teleop/udev/73-persistent-joystick.rules
+++ b/scitos_teleop/udev/73-persistent-joystick.rules
@@ -1,0 +1,1 @@
+KERNEL=="js?", ENV{ID_VENDOR}=="Logitech", ENV{ID_MODEL}=="Wireless_Gamepad_F710", NAME="

--- a/scitos_teleop/udev/73-persistent-joystick.rules
+++ b/scitos_teleop/udev/73-persistent-joystick.rules
@@ -1,1 +1,1 @@
-KERNEL=="js?", ENV{ID_VENDOR}=="Logitech", ENV{ID_MODEL}=="Wireless_Gamepad_F710", NAME="
+KERNEL=="js?", ENV{ID_VENDOR}=="Logitech", ENV{ID_MODEL}=="Wireless_Gamepad_F710", NAME="input/rumblepad"


### PR DESCRIPTION
This changes the joystick to /dev/input/rumblepad. The reason for the change is that after installing Ubuntu 12.04 64bit, the joysitck became /dev/input/js0 not /dev/input/js1. So I have created a udev rule to make it always /dev/input/rumblepad.

To use, copy the udev file to /etc/udev/rules.d/, remove and replug joystick dongle.
