### PR TITLE
[scitos_door_pass] Fixing dependencies

### DIFF
--- a/scitos_door_pass/CMakeLists.txt
+++ b/scitos_door_pass/CMakeLists.txt
@@ -137,8 +137,8 @@ add_executable(door_detect src/door_detect.cpp)
 target_link_libraries (door_pass  CDoorDetection)
 target_link_libraries (door_detect  CDoorDetection)
 
-add_dependencies(door_pass scitos_msgs_gencpp scitos_apps_msgs_genccp actionlib strands_navigation_msgs scitos_apps_msgs actionlib_msgs scitos_apps_msgs_generate_messages_cpp)
-add_dependencies(door_detect scitos_msgs_gencpp scitos_apps_msgs_genccp actionlib strands_navigation_msgs scitos_apps_msgs actionlib_msgs scitos_apps_msgs_generate_messages_cpp)
+add_dependencies(door_pass ${catkin_EXPORTED_TARGETS})
+add_dependencies(door_detect ${catkin_EXPORTED_TARGETS})
 
 #target_link_libraries (ramp_climb  CTimer)
 


### PR DESCRIPTION
Was missing the dependency for the generated strands_navigation_msgs. Used ${catkin_EXPORTED_TARGETS} to fix.
