### PR TITLE
Fixes for door passing behaviour

### DIFF
--- a/scitos_docking/CMakeLists.txt
+++ b/scitos_docking/CMakeLists.txt
@@ -4,7 +4,7 @@ project(scitos_docking)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS image_transport roscpp rospy std_msgs scitos_msgs scitos_apps_msgs message_generation genmsg actionlib_msgs actionlib move_base_msgs ros_datacentre)
+find_package(catkin REQUIRED COMPONENTS image_transport roscpp rospy std_msgs scitos_msgs scitos_apps_msgs message_generation genmsg actionlib_msgs actionlib move_base_msgs mongodb_store)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/scitos_docking/package.xml
+++ b/scitos_docking/package.xml
@@ -49,7 +49,7 @@
   <build_depend>scitos_apps_msgs</build_depend>
   <build_depend>libgsl</build_depend>
   <build_depend>libblas-dev</build_depend>
-  <build_depend>ros_datacentre</build_depend>
+  <build_depend>mongodb_store</build_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>roscpp</run_depend>

--- a/scitos_docking/src/CTransformation.cpp
+++ b/scitos_docking/src/CTransformation.cpp
@@ -263,8 +263,8 @@ void CTransformation::updateCalibration(STrackedObject own,STrackedObject statio
 
 bool CTransformation::saveParamInDB(char *param)
 {
-	ros::ServiceClient client = nh->serviceClient<ros_datacentre::SetParam>("/config_manager/save_param");
-	ros_datacentre::SetParam srv;
+	ros::ServiceClient client = nh->serviceClient<mongodb_store::SetParam>("/config_manager/save_param");
+	mongodb_store::SetParam srv;
 	ROS_INFO("Requesting update for %s", param);
 	srv.request.param = param;
 	if (client.call(srv))

--- a/scitos_docking/src/CTransformation.h
+++ b/scitos_docking/src/CTransformation.h
@@ -13,7 +13,7 @@
 #include "CCircleDetect.h"
 #include <semaphore.h> 
 #include "ros/ros.h"
-#include "ros_datacentre/SetParam.h"
+#include "mongodb_store/SetParam.h"
 
 typedef enum{
 	TRANSFORM_NONE,

--- a/scitos_door_pass/CMakeLists.txt
+++ b/scitos_door_pass/CMakeLists.txt
@@ -134,13 +134,18 @@ add_library(CDoorDetection src/CDoorDetection.cpp)
 #target_link_libraries(ramp_climb ${catkin_LIBRARIES})
 add_executable(door_pass src/door_pass.cpp)
 add_executable(door_detect src/door_detect.cpp)
+add_executable(door_detect_test src/door_detect_test.cpp)
+
 target_link_libraries (door_pass  CDoorDetection)
 target_link_libraries (door_detect  CDoorDetection)
+target_link_libraries (door_detect_test  CDoorDetection)
 
 add_dependencies(door_pass ${catkin_EXPORTED_TARGETS})
 add_dependencies(door_detect ${catkin_EXPORTED_TARGETS})
+add_dependencies(door_detect_test ${catkin_EXPORTED_TARGETS})
 
 #target_link_libraries (ramp_climb  CTimer)
 
 target_link_libraries (door_pass  ${catkin_LIBRARIES})
 target_link_libraries (door_detect  ${catkin_LIBRARIES})
+target_link_libraries (door_detect_test  ${catkin_LIBRARIES})

--- a/scitos_door_pass/src/CDoorDetection.cpp
+++ b/scitos_door_pass/src/CDoorDetection.cpp
@@ -5,7 +5,7 @@ SDoor detectDoor(std::vector<float> d,float angle_min,float angle_increment,size
 
 	int rayThreshold = 20;
 	float edgeThreshold = 0.5;		//min range step to detect an edge 
-	float minDoorWidth = 0.65;		//minimal doorWidth 
+	float minDoorWidth = 0.60;		//minimal doorWidth 
 	float maxDoorWidth = 0.85;		//maximal doorWidth
 	bool debug = true;
 	float auxiliaryDistance = 0.3;		//used to make the door position more precise

--- a/scitos_door_pass/src/door_detect_test.cpp
+++ b/scitos_door_pass/src/door_detect_test.cpp
@@ -1,0 +1,94 @@
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+#include <vector>
+#include <sensor_msgs/LaserScan.h>
+#include <geometry_msgs/Twist.h>
+#include "CDoorDetection.h"
+
+ros::Subscriber scan_sub;
+
+int measurements = 0;
+float maxDistance = 3.0;	
+int detections = 0;		
+bool debug = true;
+float doorWidth = 0;
+
+typedef enum{
+	IDLE,
+	DETECT,
+	STOPPING,
+	PREEMPTED,
+	SUCCESS,
+	FAIL
+}EClimbState;
+
+EClimbState state = IDLE;
+ 
+void scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
+{
+	if (state == DETECT){
+		SDoor door = detectDoor(scan_msg->ranges,scan_msg->angle_min,scan_msg->angle_increment,scan_msg->ranges.size(),maxDistance);
+		if (door.found){
+			doorWidth+=door.doorWidth;
+			detections++;
+			printf("Found\n");
+		}
+		else {
+			printf("Not found\n");	
+		}
+		measurements--;
+	}
+}
+
+void actionServerCallback()
+{
+	printf("Detecting\n");
+	ros::NodeHandle n;
+	scan_sub = n.subscribe("scan", 100, scanCallback);
+	printf("Subscribed\n");
+	state = DETECT;
+	measurements = 30;
+	detections = 0;
+	doorWidth = 0;
+	ros::Rate r(50); //hz
+	while (state == DETECT && ros::ok()){
+		if (measurements <= 0){
+			// if (detections > 0) state = SUCCESS; else state = FAIL;
+			// SUCCESS means that it ran to completion, result communicates open/closed
+			state = SUCCESS;
+		}
+		ros::spinOnce();
+		r.sleep();
+	}
+	bool open = false;
+	if (detections > 0){
+		float width=doorWidth/detections;
+		open=true;
+	}
+	state = STOPPING;
+	scan_sub.shutdown();
+}
+
+
+int main(int argc, char** argv)
+{
+	ros::init(argc, argv, "doorDetection");
+	ros::NodeHandle n;
+
+	ros::Rate r(30); //hz
+	
+	while (ros::ok()){
+
+		if(state == IDLE) {
+			actionServerCallback();
+		}
+		
+		if (state == STOPPING) {
+			state = IDLE;
+		}
+		
+		ros::spinOnce();
+		r.sleep();
+	}
+}
+

--- a/scitos_door_pass/src/door_pass.cpp
+++ b/scitos_door_pass/src/door_pass.cpp
@@ -79,7 +79,7 @@ void poseCallback(const geometry_msgs::Pose::ConstPtr& msg)
 		// only check for doors between the pose and the target		
 		maxDistance = fmin(sqrt(rX*rX+rY*rY), maxDistance);
 
-		printf("max distance to goal %f\n", maxDistance);
+		if (debug) printf("max distance to goal %f\n", maxDistance);
 
 		// if we're close enough to the goal, regardless of other counts
 		if(maxDistance <= goalPositionTolerance) {
@@ -160,7 +160,7 @@ void scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
 
 			// sometimes this helps get through when a bit stuck... 
 			if (misdetections > maxMisdetections/2) {
-				printf("Extending range to try to find lost door\n");
+				if (debug) printf("Extending range to try to find lost door\n");
 				longRangeMode = true;
 			} 
 

--- a/scitos_door_pass/src/door_pass.cpp
+++ b/scitos_door_pass/src/door_pass.cpp
@@ -92,10 +92,12 @@ void poseCallback(const geometry_msgs::Pose::ConstPtr& msg)
 		if(state != TURNING) {
 
 			// are we getting closer to the goal?
-			float goalDifference = previousMaxDistance - maxDistance;
+			// if we are then previousMaxDistance should be greater than maxDistance
+			float reductionInGoalDistance = previousMaxDistance - maxDistance;
 			previousMaxDistance = maxDistance;
 			
-			if(goalDifference > 0) {
+			// if goal different is smaller than 0 this means that the most recent distance the goal was greater than the previous one
+			if(reductionInGoalDistance < 0) {
 				if(++increasingGoalDistance > increasingGoalDistanceThreshold) {
 					printf("\n\nheading away from goal, failing\n\n");			
 					state = FAIL;
@@ -273,7 +275,7 @@ void actionServerCallback(const move_base_msgs::MoveBaseGoalConstPtr& goal, Serv
 	ros::Rate r(50); //hz
 
 	if (goalX == 0 && goalY == 0) state = APPROACH;
-	
+
 	while (state == TURNING || state == DETECT || state == APPROACH || state == ADJUST || state == PASS || state == LEAVE){
 		
 		if (misdetections > maxMisdetections || state == LEAVE){
@@ -291,7 +293,7 @@ void actionServerCallback(const move_base_msgs::MoveBaseGoalConstPtr& goal, Serv
 	}
 	
 
-	if (debug) printf("Out of loop: %d\n", state);
+	// if (debug) printf("Out of loop: %d\n", state);
 
 	
 	if (state == FAIL) {

--- a/scitos_door_pass/src/door_pass.cpp
+++ b/scitos_door_pass/src/door_pass.cpp
@@ -13,8 +13,8 @@ Server *server;
 ros::Subscriber scan_sub;
 ros::Subscriber robot_pose;
 
-float goalPositionTolerance = 0.08;
-float minRotate = 0.3;
+float goalPositionTolerance = 0.09;
+float minRotate = 0.3; //minimum amount to rotate -- 0.3 was needed at BHAM to prevent getting stuck on carpet
 float defaultMaxDistance = 3.0;
 float maxDistance = defaultMaxDistance;		//max range taken into consideration
 float defaultSpeed = 0.15;		//default forward speed of the robot
@@ -24,6 +24,10 @@ int passCounter = 0;			//measurements
 int maxMisdetections = 50;		//decides when door not detected
 int misdetections = 0;
 bool debug = true;
+
+float previousMaxDistance = 0; 
+int increasingGoalDistance = 0; //pose updates
+int increasingGoalDistanceThreshold = 15; //pose updates
 
 typedef enum{
 	IDLE,
@@ -71,47 +75,57 @@ void poseCallback(const geometry_msgs::Pose::ConstPtr& msg)
 		rX = goalX - msg->position.x;
 		rY = goalY - msg->position.y;
 
-		
+		// only check for doors between the pose and the target		
+		maxDistance = fmin(sqrt(rX*rX+rY*rY), maxDistance);
 
-		printf("goal dist (%f,%f)\n", fabs(rX), fabs(rY));
+		printf("max distance to goal %f\n", maxDistance);
 
-		if(fabs(rX) <= goalPositionTolerance && fabs(rY) <= goalPositionTolerance) {
+		// if we're close enough to the goal, regardless of other counts
+		if(maxDistance <= goalPositionTolerance) {
 			printf("within range of target, stopping");			
 			state = LEAVE;
 		}
+		
+
+		// if we're not turning we should be getting closer to the goal
+		if(state != TURNING) {
+
+			// are we getting closer to the goal?
+			float goalDifference = previousMaxDistance - maxDistance;
+			previousMaxDistance = maxDistance;
+			
+			if(goalDifference > 0) {
+				if(++increasingGoalDistance > increasingGoalDistanceThreshold) {
+					printf("heading away from goal, failing");			
+					state = FAIL;
+				}
+			}
+			else {
+				increasingGoalDistance = 0;
+			}
+
+		}
+		else { //if (state == TURNING){
+			float currentAngle = tf::getYaw(msg->orientation);
+
+			base_cmd.linear.x = 0; 
+			currentAngle = (atan2(rY,rX)-currentAngle);
+
+			while (currentAngle >= M_PI) currentAngle-= 2*M_PI;
+			while (currentAngle < -M_PI) currentAngle += 2*M_PI;
+
+			base_cmd.angular.z = boundRotation(currentAngle*0.5);
+
+
+
+			if (fabs(currentAngle) < 0.1){
+				base_cmd.angular.z = 0;
+				state = APPROACH;
+			} 
+
+			cmd_vel.publish(base_cmd);
+		}
 	}
-	
-	if (state == TURNING){
-		float rX,rY;
-		rX=rY=0;
-
-		// difference in x y between current and target
-		rX = goalX - msg->position.x;
-		rY = goalY - msg->position.y;
-		float currentAngle = tf::getYaw(msg->orientation);
-
-		base_cmd.linear.x = 0; 
-		currentAngle = (atan2(rY,rX)-currentAngle);
-
-		while (currentAngle >= M_PI) currentAngle-= 2*M_PI;
-		while (currentAngle < -M_PI) currentAngle += 2*M_PI;
-
-		base_cmd.angular.z = boundRotation(currentAngle*0.5);
-
-		// only check for doors between the pose and the target
-
-		maxDistance = fmin(sqrt(rX*rX+rY*rY),maxDistance);
-
-		printf("maxDistance %f\n", maxDistance);
-
-		if (fabs(currentAngle) < 0.1){
-			base_cmd.angular.z = 0;
-			state = APPROACH;
-		} 
-
-		cmd_vel.publish(base_cmd);
-	}
-	
 
 }
 
@@ -219,8 +233,16 @@ void actionServerCallback(const move_base_msgs::MoveBaseGoalConstPtr& goal, Serv
 	move_base_msgs::MoveBaseResult result;
 	goalX = goal->target_pose.pose.position.x;
 	goalY = goal->target_pose.pose.position.y;
+	
+	// reset variables
 	misdetections = 0;
+	maxDistance = defaultMaxDistance;
+	previousMaxDistance = maxDistance;
+	increasingGoalDistance = 0;
+
+
 	state = TURNING;
+
 
 	ros::Rate r(50); //hz
 
@@ -228,7 +250,12 @@ void actionServerCallback(const move_base_msgs::MoveBaseGoalConstPtr& goal, Serv
 	while (state == TURNING || state == DETECT || state == APPROACH || state == ADJUST || state == PASS || state == LEAVE){
 		
 		if (misdetections > maxMisdetections || state == LEAVE){
-			if (state == LEAVE) state = SUCCESS; else state = FAIL;
+			if (state == LEAVE) {
+				state = SUCCESS;
+			}
+			else {
+				state = FAIL;
+			}
 		}
 		else if (misdetections > maxMisdetections/2) {
 			printf("Trying a different distance\n");

--- a/scitos_door_pass/src/door_pass.cpp
+++ b/scitos_door_pass/src/door_pass.cpp
@@ -172,7 +172,7 @@ void scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
 			if (door.found){
 				misdetections=0;
 				if (state == APPROACH){
-					if (debug) printf("Moving to %f %f ",door.auxX,door.auxY);
+					if (debug) printf("Moving to %f %f %d",door.auxX,door.auxY, passCounter);
 					if (door.auxX < 0.05) passCounter++; else passCounter=0;
 					if (passCounter >  passCounterLimit){
 						state = ADJUST;
@@ -194,12 +194,22 @@ void scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
 
 			}
 			else {
+				if (debug) printf("Missed door");
 				misdetections++;
 			}
 
 			if (state == DETECT){
-				if (door.found) passCounter++; else passCounter=0;
-				if (passCounter >  passCounterLimit) state = LEAVE;
+				if (door.found) {
+					passCounter++; 
+				}
+				else {
+					passCounter=0;
+				}
+				
+				if (passCounter >  passCounterLimit) {
+					if (debug) printf("Leaving from DETECT");					
+					state = LEAVE;
+				}
 			}
 		}
 		


### PR DESCRIPTION
Two changes:

1) counts misdetections which were previously ignoring, causing it to never fail when not facing a door.

2) changed passCounter reset to -30 instead of -50 which stops the robot a little earlier when moving successful. this prevents Bob for charging off down a corridor when leaving an office.

Also added a little more logging for me to understand things and switched to ros rate objects for clarity.
