### PR TITLE
Renamed ros_datacentre to mongodb_store

### DIFF
--- a/scitos_docking/CMakeLists.txt
+++ b/scitos_docking/CMakeLists.txt
@@ -4,7 +4,7 @@ project(scitos_docking)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS image_transport roscpp rospy std_msgs scitos_msgs scitos_apps_msgs message_generation genmsg actionlib_msgs actionlib move_base_msgs ros_datacentre)
+find_package(catkin REQUIRED COMPONENTS image_transport roscpp rospy std_msgs scitos_msgs scitos_apps_msgs message_generation genmsg actionlib_msgs actionlib move_base_msgs mongodb_store)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/scitos_docking/package.xml
+++ b/scitos_docking/package.xml
@@ -49,7 +49,7 @@
   <build_depend>scitos_apps_msgs</build_depend>
   <build_depend>libgsl</build_depend>
   <build_depend>libblas-dev</build_depend>
-  <build_depend>ros_datacentre</build_depend>
+  <build_depend>mongodb_store</build_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>roscpp</run_depend>

--- a/scitos_docking/src/CTransformation.cpp
+++ b/scitos_docking/src/CTransformation.cpp
@@ -263,8 +263,8 @@ void CTransformation::updateCalibration(STrackedObject own,STrackedObject statio
 
 bool CTransformation::saveParamInDB(char *param)
 {
-	ros::ServiceClient client = nh->serviceClient<ros_datacentre::SetParam>("/config_manager/save_param");
-	ros_datacentre::SetParam srv;
+	ros::ServiceClient client = nh->serviceClient<mongodb_store::SetParam>("/config_manager/save_param");
+	mongodb_store::SetParam srv;
 	ROS_INFO("Requesting update for %s", param);
 	srv.request.param = param;
 	if (client.call(srv))

--- a/scitos_docking/src/CTransformation.h
+++ b/scitos_docking/src/CTransformation.h
@@ -13,7 +13,7 @@
 #include "CCircleDetect.h"
 #include <semaphore.h> 
 #include "ros/ros.h"
-#include "ros_datacentre/SetParam.h"
+#include "mongodb_store/SetParam.h"
 
 typedef enum{
 	TRANSFORM_NONE,


### PR DESCRIPTION
This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.

Needs strands-project/ros_datacentre#76 to me merged first.
