### PR TITLE
[scitos_door_pass] DoorCheck action has been moved from strands_navigation_msgs

### DIFF
--- a/scitos_door_pass/CMakeLists.txt
+++ b/scitos_door_pass/CMakeLists.txt
@@ -4,7 +4,17 @@ project(scitos_door_pass)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs nav_msgs scitos_msgs strands_navigation_msgs message_generation genmsg actionlib_msgs actionlib)
+find_package(catkin REQUIRED COMPONENTS 
+    roscpp 
+    rospy 
+    std_msgs 
+    nav_msgs 
+    scitos_msgs 
+    message_generation 
+    genmsg 
+    actionlib_msgs 
+    actionlib
+    )
 set ( CMAKE_CXX_FLAGS "-ggdb")
 
 ## System dependencies are found with CMake's conventions
@@ -33,11 +43,18 @@ set ( CMAKE_CXX_FLAGS "-ggdb")
   # Charging.srv
  #)
 
+add_action_files(
+	DIRECTORY action 
+	FILES 
+	DoorCheck.action
+)
+
 ## Generate added messages and services with any dependencies listed here
- #generate_messages(
-	#	 DEPENDENCIES
-		# std_msgs 
-		 #)
+generate_messages(
+    DEPENDENCIES
+    std_msgs 
+    actionlib_msgs
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -137,8 +154,9 @@ add_executable(door_detect src/door_detect.cpp)
 target_link_libraries (door_pass  CDoorDetection)
 target_link_libraries (door_detect  CDoorDetection)
 
-add_dependencies(door_pass ${catkin_EXPORTED_TARGETS})
-add_dependencies(door_detect ${catkin_EXPORTED_TARGETS})
+add_dependencies(CDoorDetection ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(door_pass ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(door_detect ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
 
 #target_link_libraries (ramp_climb  CTimer)
 

--- a/scitos_door_pass/action/DoorCheck.action
+++ b/scitos_door_pass/action/DoorCheck.action
@@ -1,0 +1,8 @@
+#goal definition
+---
+#result definition
+bool open
+float64 width
+---
+#feedback
+string status

--- a/scitos_door_pass/package.xml
+++ b/scitos_door_pass/package.xml
@@ -45,7 +45,6 @@
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>scitos_msgs</build_depend>
-  <build_depend>strands_navigation_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>image_transport</run_depend>

--- a/scitos_door_pass/src/door_detect.cpp
+++ b/scitos_door_pass/src/door_detect.cpp
@@ -3,11 +3,11 @@
 #include <vector>
 #include <sensor_msgs/LaserScan.h>
 #include <geometry_msgs/Twist.h>
-#include <strands_navigation_msgs/DoorCheckAction.h>
+#include <scitos_door_pass/DoorCheckAction.h>
 #include <actionlib/server/simple_action_server.h>
 #include "CDoorDetection.h"
 
-typedef actionlib::SimpleActionServer<strands_navigation_msgs::DoorCheckAction> Server;
+typedef actionlib::SimpleActionServer<scitos_door_pass::DoorCheckAction> Server;
 Server *server;
 ros::Subscriber scan_sub;
 
@@ -40,9 +40,9 @@ void scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
 	}
 }
 
-void actionServerCallback(const strands_navigation_msgs::DoorCheckGoalConstPtr& goal, Server* as)
+void actionServerCallback(const scitos_door_pass::DoorCheckGoalConstPtr& goal, Server* as)
 {
-	strands_navigation_msgs::DoorCheckResult result;
+	scitos_door_pass::DoorCheckResult result;
 	state = DETECT;
 	measurements = 30;
 	detections = 0;


### PR DESCRIPTION
To reduce dependencies for release. The files had only one commit in its history, therefore it has just been moved instead of using git subtree and creating a lot more unnecessary commits.
