### PR TITLE
Fixing #112: Replacing opencv2 dependency with cv_bridge to be distribution independent.

### DIFF
--- a/scitos_docking/package.xml
+++ b/scitos_docking/package.xml
@@ -16,6 +16,7 @@
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>boost</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
@@ -26,7 +27,6 @@
   <build_depend>mongodb_store</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>opencv2</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>scitos_msgs</build_depend>
@@ -38,6 +38,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>boost</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
@@ -48,7 +49,6 @@
   <run_depend>mongodb_store</run_depend>
   <run_depend>move_base_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
-  <run_depend>opencv2</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>scitos_msgs</run_depend>


### PR DESCRIPTION
`opencv2` does not exists under `indigo` any more. `cv_bridge` is pulling in the correct opencv packages for both distributions.
