### PR TITLE
Fix gamepad udev rule for new udev version.

### DIFF
--- a/scitos_teleop/udev/73-scitos-teleop-persistent-joystick.rules
+++ b/scitos_teleop/udev/73-scitos-teleop-persistent-joystick.rules
@@ -1,1 +1,1 @@
-KERNEL=="js?", ENV{ID_VENDOR}=="Logitech", ENV{ID_MODEL}=="Wireless_Gamepad_F710", NAME="input/rumblepad"
+KERNEL=="js?", ENV{ID_VENDOR}=="Logitech", ENV{ID_MODEL}=="Wireless_Gamepad_F710", SYMLINK+="input/rumblepad"


### PR DESCRIPTION
In newer versions, it is no more possible/supported to set `NAME=`. I can't find the reference anymore, but I read it in an official changelog.
