### PR TITLE
New ptu_follow_frame package

### DIFF
--- a/ptu_follow_frame/CMakeLists.txt
+++ b/ptu_follow_frame/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(ptu_follow_frame)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  sensor_msgs
+  message_generation  
+  tf
+)
+
+# catkin_python_setup()
+
+add_service_files(
+  FILES
+  StartFollowing.srv
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES ptu_follow_frame
+#  CATKIN_DEPENDS geometry_msgs rospy sensor_msgs
+#  DEPENDS system_lib
+)
+
+# include_directories(
+#  ${catkin_INCLUDE_DIRS}
+# )
+
+#############
+## Install ##
+#############
+
+install(PROGRAMS
+  scripts/ptu_follow.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_ptu_follow_frame.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/ptu_follow_frame/README.md
+++ b/ptu_follow_frame/README.md
@@ -1,0 +1,15 @@
+ptu_follow_frame
+================
+
+This package provides a ROS node that controls the PTU so as to keep the `ptu_mount` frame X axis pointing to the origin of a user supplied TF frame.
+
+It is activated and deactivated using two service calls:
+
+- `/ptu_follow_frame/set_following : ptu_follow_frame/StartFollowing`
+ call this with a string representation of the target frame, for example
+ `map` to have the ptu frame follower track that frame. 
+- `/ptu_follow_frame/stop_following : std_srv/Empty`
+ call this to stop the ptu frame follower from tracking whatever frame it currently tracks.
+
+During tracking, the PTU will be in velocity control mode and no other node should try to control it.
+

--- a/ptu_follow_frame/package.xml
+++ b/ptu_follow_frame/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package>
+  <name>ptu_follow_frame</name>
+  <version>0.0.16</version>
+  <description>
+   The ptu_follow_frame package provides a node that keeps the PTU targeted
+   at the origin of a given frame.
+  </description>
+
+  <maintainer email="cburbridge@gmail.com">Chris Burbridge</maintainer>
+  <author email="cburbridge@gmail.com">Chris Burbridge</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>message_generation</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/ptu_follow_frame/scripts/ptu_follow.py
+++ b/ptu_follow_frame/scripts/ptu_follow.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+import rospy
+import tf
+from ptu_follow_frame.srv import StartFollowing, StartFollowingResponse
+from std_srvs.srv import Empty, EmptyResponse
+from sensor_msgs.msg import JointState
+import math
+import threading
+
+SOFT_PAN_LIMIT_UPPER = 1.9
+SOFT_PAN_LIMIT_LOWER = -1.9
+SOFT_TILT_LIMIT_UPPER = 0.2
+SOFT_TILT_LIMIT_LOWER = -0.1
+MAX_PAN_VEL = 3
+MIN_PAN_VEL = -3
+MAX_TILT_VEL = 2
+MIN_TILT_VEL = -2
+PAN_ACCEL=1
+TILT_ACCEL=1
+
+class FollowFrame(object):
+    """
+    Controls a PTU to keep the origin in a given frame in the centre
+    of the PTU frame.
+    """
+
+    def __init__(self):
+        """Constructor"""
+        self._target_frame = None
+        self._follow_frequency = 10 # Hz
+        self._running = False
+        self._cmd_state = JointState()
+        self._cmd_state.name = ["pan", "tilt"]
+        self._cmd_state.position = [0, 0]
+        self._cmd_state.velocity = [0, 0]
+        self._last_cmd_vel=[0,0]
+        self._ptu_state = None
+        
+        if rospy.get_name() == "":
+            print "FollowFrame class needs to be created in a ROS node."
+            print "Make sure rospy.init_node() is called before instantiation."
+            return
+        
+        # set up services
+        self._start_srv = rospy.Service(rospy.get_name()+"/set_following",
+                                        StartFollowing,
+                                        self._on_set_following_srv_cb)
+        self._stop_srv = rospy.Service(rospy.get_name()+"/stop_following",
+                                       Empty,
+                                       self._on_stop_following_srv_cb)
+        
+        # command PTU publisher
+        self._ptu_cmd = rospy.Publisher("/ptu/cmd_vel", JointState, queue_size=1)
+        # state sub
+        self._ptu_sub = rospy.Subscriber("/ptu/state", JointState,
+                                                self._on_ptu_state)
+    
+    def _on_set_following_srv_cb(self, req):
+        rospy.loginfo("Following activated on frame %s"% req.target_frame_id)
+        response = StartFollowingResponse()
+        r = self.set_following(req.target_frame_id)
+        response.response = r[0]
+        response.activated = r[1]
+        return response
+    
+    def _on_stop_following_srv_cb(self, req):
+        rospy.loginfo("Stopping PTU following.")
+        self.stop_following()
+        return EmptyResponse()
+    
+    def _on_ptu_state(self, state):
+        self._ptu_state = state
+    
+    def _main_loop(self):
+        rater = rospy.Rate(self._follow_frequency)
+        while self._running:
+            t = self._tf.getLatestCommonTime("/ptu_mount", self._target_frame)
+            position, quaternion = self._tf.lookupTransform("/ptu_mount",
+                                                           self._target_frame,
+                                                           t)
+
+            yaw = math.atan2(position[1], position[0])
+            roll = math.atan2(position[2], position[0])
+            print "=> drive yaw=", yaw
+            print "=> drive roll=", roll
+
+            if self._ptu_state is None:
+                rospy.logwarn("Not got any PTU status info....")
+                continue
+
+            # If the yaw angle would pass the back, flip it
+            new_pan=self._ptu_state.position[0] + yaw
+            if new_pan < -math.pi:
+                yaw=2*math.pi-yaw
+            if new_pan > math.pi:
+                yaw=-2*math.pi+yaw
+
+            self._cmd_state.velocity[0] = yaw
+            self._cmd_state.velocity[0] = min(self._cmd_state.velocity[0], MAX_PAN_VEL)
+            self._cmd_state.velocity[0] = max(self._cmd_state.velocity[0], MIN_PAN_VEL)
+            self._cmd_state.velocity[1] = -roll
+            self._cmd_state.velocity[1] = min(self._cmd_state.velocity[1], MAX_TILT_VEL)
+            self._cmd_state.velocity[1] = max(self._cmd_state.velocity[1], MIN_TILT_VEL)
+
+
+            # Check the acceleration limits
+            if self._cmd_state.velocity[0] - self._last_cmd_vel[0] < - PAN_ACCEL:
+                self._cmd_state.velocity[0] = self._last_cmd_vel[0] - PAN_ACCEL
+            if self._cmd_state.velocity[0] - self._last_cmd_vel[0] > PAN_ACCEL:
+                self._cmd_state.velocity[0] = self._last_cmd_vel[0] + PAN_ACCEL
+            if self._cmd_state.velocity[1] - self._last_cmd_vel[1] < - TILT_ACCEL:
+                self._cmd_state.velocity[1] = self._last_cmd_vel[1] - TILT_ACCEL
+            if self._cmd_state.velocity[1] - self._last_cmd_vel[1] > TILT_ACCEL:
+                self._cmd_state.velocity[1] = self._last_cmd_vel[1] + TILT_ACCEL
+
+
+            # Cut it off, dont try and drive beyond the limits.
+            if (self._ptu_state.position[0] > SOFT_PAN_LIMIT_UPPER):
+                self._cmd_state.velocity[0] = min(0, self._cmd_state.velocity[0])
+            if (self._ptu_state.position[0] < SOFT_PAN_LIMIT_LOWER):
+                self._cmd_state.velocity[0] = max(0, self._cmd_state.velocity[0])
+            if (self._ptu_state.position[1] > SOFT_TILT_LIMIT_UPPER):
+                self._cmd_state.velocity[1] = min(0, self._cmd_state.velocity[1])
+            if (self._ptu_state.position[1] < SOFT_TILT_LIMIT_LOWER):
+                self._cmd_state.velocity[1] = max(0, self._cmd_state.velocity[1])
+
+            self._ptu_cmd.publish(self._cmd_state)
+            self._last_cmd_vel[0]=self._cmd_state.velocity[0]
+            self._last_cmd_vel[1]=self._cmd_state.velocity[1]
+
+            try:
+                rater.sleep()
+            except:
+                # Get out of here.#
+                self._running = False
+    
+    def set_following(self, frame_id):
+        if self._running:
+            return "already active.", False
+        
+        self._target_frame = frame_id
+        self._tf = tf.TransformListener()
+        rospy.loginfo("PTU Frame follower initialising TF...")
+        rospy.sleep(1)
+        rospy.loginfo("ok.")
+        if not self._tf.frameExists(frame_id):
+            return ("frame does not exist. maybe? I know of:\n" +
+                    self._tf.allFramesAsString(),
+                    False)
+        
+        # Run the main loop in a thread
+        self._running = True
+        self._running_thread = threading.Thread(target=self._main_loop)
+        self._running_thread.start()
+        
+        return "ok", True
+                                                
+    
+    def stop_following(self):
+        if not self._running:
+            return
+        
+        self._tf = None
+        self._target_frame = None
+        
+        # Stop the main loop thread
+        self._running = False
+        self._running_thread.join()
+        
+    def set_cmd_freq(self, hz):
+        if not self._running:
+            self._follow_frequency = hz
+        else:
+            prev_follow_frame = self._target_frame
+            self.stop_following()
+            self._follow_frequency = hz
+            self.set_following(prev_follow_frame)
+
+if __name__ == '__main__':
+    rospy.init_node("ptu_follow_frame")
+    follower = FollowFrame()
+    follower.set_cmd_freq(50)
+    rospy.spin()

--- a/ptu_follow_frame/srv/StartFollowing.srv
+++ b/ptu_follow_frame/srv/StartFollowing.srv
@@ -1,0 +1,4 @@
+string target_frame_id
+---
+string response
+bool activated


### PR DESCRIPTION
This adds a new package "ptu_follow_frame" that controls the PTU so as to keep the `ptu_mount` frame X axis pointing to the origin of a user supplied TF frame.

It is activated and deactivated using two service calls:
- `/ptu_follow_frame/set_following : ptu_follow_frame/StartFollowing`
  call this with a string representation of the target frame, for example
  `map` to have the ptu frame follower track that frame. 
- `/ptu_follow_frame/stop_following : std_srv/Empty`
  call this to stop the ptu frame follower from tracking whatever frame it currently tracks.

During tracking, the PTU will be in velocity control mode and no other node should try to control it.
