### PR TITLE
cmd_vel goes to 0 faster

### DIFF
--- a/scitos_teleop/src/base_teleop.cpp
+++ b/scitos_teleop/src/base_teleop.cpp
@@ -17,7 +17,7 @@ void controlCallback(const sensor_msgs::Joy::ConstPtr& msg)
 		t.linear.x += 0.1*l_scale_ * msg->axes[7];
 		t.angular.z = a_scale_ * msg->axes[6];
 	}else{
-		t.linear.x = 0.9*t.linear.x + 0.1*l_scale_ * msg->axes[1];
+		t.linear.x = 0.5*t.linear.x + 0.5*l_scale_ * msg->axes[1];
 		t.angular.z = 0.5*t.angular.z + 0.5*a_scale_ * msg->axes[0];
 	}
 	if (t.linear.x > l_scale_) t.linear.x = l_scale_; 


### PR DESCRIPTION
we've been having problems with the robots taking too much time to stop after we stop sending commands this PR makes the stop more reactive. With the current firmware there's no need to slowly reduce speed as the firmware itself does that